### PR TITLE
chore: limit renovate updates to template dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -15,4 +15,8 @@
       },
     },
   ],
+  includePaths: [
+    '{{cookiecutter.project_slug}}/package.json',
+    '{{cookiecutter.project_slug}}/package-lock.json',
+  ],
 }


### PR DESCRIPTION
Related to https://github.com/netlify/node-template/pull/14#issuecomment-753985005
@ehmicky I couldn't figure out anything from the renovate logs, so I'm trying to limit the config.
Maybe having two `package.json` files are causing this issue.