### PR TITLE
fix: update PR labeler to use a matrix

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/labeler.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/labeler.yml
@@ -7,24 +7,20 @@ jobs:
   label-pr:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pr:
+          [
+            { prefix: 'fix', type: 'bug' },
+            { prefix: 'chore', type: 'chore' },
+            { prefix: 'test', type: 'chore' },
+            { prefix: 'ci', type: 'chore' },
+            { prefix: 'feat', type: 'feature' },
+            { prefix: 'security', type: 'security' },
+          ]
     steps:
-      - uses: erezrokah/pr-labeler-action@v1.0.0
-        if: startsWith(github.event.pull_request.title, 'fix')
+      - uses: netlify/pr-labeler-action@v1.0.0
+        if: startsWith(github.event.pull_request.title, matrix.pr.prefix)
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
-          label: 'type: bug'
-      - uses: erezrokah/pr-labeler-action@v1.0.0
-        if: startsWith(github.event.pull_request.title, 'chore') || startsWith(github.event.pull_request.title, 'ci')
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          label: 'type: chore'
-      - uses: erezrokah/pr-labeler-action@v1.0.0
-        if: startsWith(github.event.pull_request.title, 'feat')
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          label: 'type: feature'
-      - uses: erezrokah/pr-labeler-action@v1.0.0
-        if: startsWith(github.event.pull_request.title, 'security')
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          label: 'type: security'
+          label: 'type: ${{ matrix.pr.type }}'


### PR DESCRIPTION
Updates the action to use a matrix and changes `erezrokah` to `netlify` (we transferred the action to our organisation).