### PR TITLE
feat: add husky to dev dependencies

### DIFF
--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -51,6 +51,7 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@netlify/eslint-config-node": "^2.0.0",
     "ava": "^2.4.0",
+    "husky": "^4.3.8",
     "nyc": "^15.0.0"
   },
   "engines": {


### PR DESCRIPTION
`husky` needs to be included as a dev dependency for the hooks to work