### PR TITLE
fix: fix `files` in `package.json`

### DIFF
--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -4,7 +4,8 @@
   "version": "{{cookiecutter.project_version}}",
   "description": "{{cookiecutter.project_description}}",
   "files": [
-    "src"
+    "src/**/*.js",
+    "!src/**/*.test.js"
   ],
   "scripts": {
     "prepublishOnly": "npm ci && npm test",


### PR DESCRIPTION
npm 7 changed the way globbing patterns are interpreted in `files` in `package.json`. This is undocumented, so I'm not sure whether this is a bug or not. This results in all `*~` files (Vim temporary files) to be published to npm, which can double the package size. 

This PR fixes this. I ran `npm pack --dry` before and after to ensure no files were being omitted.