### PR TITLE
chore: rename master to main

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
   extends: ['github>netlify/renovate-config:default'],
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
-  masterIssue: true,
+  dependencyDashboard: true,
   automerge: false,
   packageRules: [
     {

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,4 +27,4 @@ npx envinfo --system --binaries
 **Pull requests**
 
 Pull requests are welcome! If you would like to help us fix this bug, please check our
-[contributions guidelines](../blob/master/CONTRIBUTING.md).
+[contributions guidelines](../blob/main/CONTRIBUTING.md).

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/feature_request.md
@@ -36,5 +36,5 @@ Yes/No.
 
 <!--
 Pull requests are welcome! If you would like to help us add this feature, please check our
-[contributions guidelines](../blob/master/CONTRIBUTING.md).
+[contributions guidelines](../blob/main/CONTRIBUTING.md).
 -->

--- a/{{cookiecutter.project_slug}}/.github/pull_request_template.md
+++ b/{{cookiecutter.project_slug}}/.github/pull_request_template.md
@@ -26,7 +26,7 @@ Example: Another solution would be [...]
 
 Please add a `x` inside each checkbox:
 
-- [ ] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
+- [ ] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
 - [ ] The status checks are successful (continuous integration). Those can be seen below.
 
 **A picture of a cute animal (not mandatory but encouraged)**

--- a/{{cookiecutter.project_slug}}/.github/workflows/fossa.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/fossa.yml
@@ -3,7 +3,7 @@ name: Dependency License Scanning
 on:
   push:
     branches:
-      - master
+      - main
 
 defaults:
   run:

--- a/{{cookiecutter.project_slug}}/.github/workflows/release-please.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@
  on:
    push:
      branches:
-       - master
+       - main
  jobs:
    release-please:
      runs-on: ubuntu-latest

--- a/{{cookiecutter.project_slug}}/.github/workflows/workflow.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   # Ensure GitHub actions are not run twice for same commits
   push:
-    branches: [master]
+    branches: [main]
     tags: ['*']
   pull_request:
     types: [opened, synchronize, reopened]

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -39,6 +39,6 @@ After submitting the pull request, please make sure the Continuous Integration c
 ## Releasing
 
 1. Merge the release PR
-2. Switch to the default branch `git checkout master`
+2. Switch to the default branch `git checkout main`
 3. Pull latest changes `git pull`
 4. Publish the package `npm publish`

--- a/{{cookiecutter.project_slug}}/renovate.json5
+++ b/{{cookiecutter.project_slug}}/renovate.json5
@@ -2,7 +2,7 @@
   extends: ['github>netlify/renovate-config:default'],
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
-  masterIssue: true,
+  dependencyDashboard: true,
   automerge: false,
   packageRules: [
     {


### PR DESCRIPTION
Update any `master` references to `main` since that's the new default for GitHub repos