### PR TITLE
chore(renovate): enable automerge

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,26 @@
+name: Label PR
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  label-pr:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pr:
+          [
+            { prefix: 'fix', type: 'bug' },
+            { prefix: 'chore', type: 'chore' },
+            { prefix: 'test', type: 'chore' },
+            { prefix: 'ci', type: 'chore' },
+            { prefix: 'feat', type: 'feature' },
+            { prefix: 'security', type: 'security' },
+          ]
+    steps:
+      - uses: netlify/pr-labeler-action@v1.0.0
+        if: startsWith(github.event.pull_request.title, matrix.pr.prefix)
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          label: 'type: ${{ matrix.pr.type }}'

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,7 @@
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
   dependencyDashboard: true,
-  automerge: false,
+  automerge: true,
   packageRules: [
     {
       // Those cannot be upgraded to a major version until we drop support for Node 8

--- a/{{cookiecutter.project_slug}}/renovate.json5
+++ b/{{cookiecutter.project_slug}}/renovate.json5
@@ -3,7 +3,7 @@
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
   dependencyDashboard: true,
-  automerge: false,
+  automerge: true,
   packageRules: [
     {
       // Those cannot be upgraded to a major version until we drop support for Node 8


### PR DESCRIPTION
Enables renovate automerge for this repo.

I've added the PR labeler so the required label status check will pass for renovate PRs.
I've also requested to install https://github.com/apps/renovate-approve so it approves renovate PRs