### PR TITLE
chore(ci): cache npm cache dir between workflow execs

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/release-please.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release-please.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '*'
+          cache: 'npm'
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/workflow.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/workflow.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [8.17.0, '*']
+        node-version: [10.18.0, '*']
         exclude:
           - os: macOS-latest
-            node-version: 8.17.0
+            node-version: 10.18.0
           - os: windows-latest
-            node-version: 8.17.0
+            node-version: 10.18.0
       fail-fast: false
     steps:
       - name: Git checkout
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
           check-latest: true
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/js-client/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Related with https://github.com/netlify/team-dev/issues/31 - cache `npm cache` between workflow executions. Also took the chance to move our minimum CI node version to `v10.18.0` (see https://github.com/netlify/build/issues/3321)

