### PR TITLE
chore(kodiak): auto approve renovate PRs

### DIFF
--- a/{{cookiecutter.project_slug}}.github/.kodiak.toml
+++ b/{{cookiecutter.project_slug}}.github/.kodiak.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[merge.automerge_dependencies]
+versions = ["minor", "patch"]
+usernames = ["renovate"]
+
+[approve]
+auto_approve_usernames = ["renovate"]


### PR DESCRIPTION
Configures Kodiak to auto approve renovate PRs. Replaces renovate-approve bot.